### PR TITLE
Multiple "alpha" changes & a bug fix

### DIFF
--- a/Web/Index.html
+++ b/Web/Index.html
@@ -51,7 +51,7 @@
 		</script>
 		<script id="vertexShaderFirstPass" type="x-shader/x-vertex">
 			varying vec3 worldSpaceCoords;
-			
+
 			void main()
 			{
 				//Set the world space coordinates of the back faces vertices as output.
@@ -65,8 +65,12 @@
 			uniform sampler2D tex, cubeTex, transferTex;
 			uniform float steps;
 			uniform float alphaCorrection;
-			const int MAX_STEPS = 512;
-			
+			// The maximum distance through our rendering volume is sqrt(3).
+			// The maximum number of steps we take to travel a distance of 1 is 512.
+			// ceil( sqrt(3) * 512 ) = 887
+			// This prevents the back of the image from getting cut off when steps=512 & viewing diagonally.
+			const int MAX_STEPS = 887;
+
 			//Acts like a texture3D using Z slices and trilinear filtering.
 			vec4 sampleAs3DTexture( vec3 texCoord )
 			{
@@ -76,32 +80,32 @@
 				//The z coordinate determines which Z slice we have to look for.
 				//Z slice number goes from 0 to 255.
 				float zSliceNumber1 = floor(texCoord.z  * 255.0);
-				
+
 				//As we use trilinear we go the next Z slice.
 				float zSliceNumber2 = min( zSliceNumber1 + 1.0, 255.0); //Clamp to 255
-				
+
 				//The Z slices are stored in a matrix of 16x16 of Z slices.
 				//The original UV coordinates have to be rescaled by the tile numbers in each row and column.
 				texCoord.xy /= 16.0;
 
 				texCoordSlice1 = texCoordSlice2 = texCoord.xy;
-											
+
 				//Add an offset to the original UV coordinates depending on the row and column number.
 				texCoordSlice1.x += (mod(zSliceNumber1, 16.0 ) / 16.0);
 				texCoordSlice1.y += floor((255.0 - zSliceNumber1) / 16.0) / 16.0;
-					
+
 				texCoordSlice2.x += (mod(zSliceNumber2, 16.0 ) / 16.0);
 				texCoordSlice2.y += floor((255.0 - zSliceNumber2) / 16.0) / 16.0;
-				
+
 				//Get the opacity value from the 2D texture.
 				//Bilinear filtering is done at each texture2D by default.
 				colorSlice1 = texture2D( cubeTex, texCoordSlice1 );
 				colorSlice2 = texture2D( cubeTex, texCoordSlice2 );
-				
+
 				//Based on the opacity obtained earlier, get the RGB color in the transfer function texture.
 				colorSlice1.rgb = texture2D( transferTex, vec2( colorSlice1.a, 1.0) ).rgb;
 				colorSlice2.rgb = texture2D( transferTex, vec2( colorSlice2.a, 1.0) ).rgb;
-				
+
 				//How distant is zSlice1 to ZSlice2. Used to interpolate between one Z slice and the other.
 				float zDifference = mod(texCoord.z * 255.0, 1.0);
 
@@ -109,7 +113,7 @@
 				return mix(colorSlice1, colorSlice2, zDifference) ;
 			}
 
-		
+
 			void main( void ) {
 
 				//Transform the coordinates it from [-1;1] to [0;1]
@@ -124,9 +128,9 @@
 
 				//The direction from the front position to back position.
 				vec3 dir = backPos - frontPos;
-				
-				float rayLength = length(dir); 
-				
+
+				float rayLength = length(dir);
+
 				//Calculate how long to increment in each step.
 				float delta = 1.0 / steps;
 
@@ -136,52 +140,62 @@
 
 				//Start the ray casting from the front position.
 				vec3 currentPosition = frontPos;
-				
+
 				//The color accumulator.
 				vec4 accumulatedColor = vec4(0.0);
-				
+
 				//The alpha value accumulated so far.
 				float accumulatedAlpha = 0.0;
-				
+
 				//How long has the ray travelled so far.
 				float accumulatedLength = 0.0;
-				
+
+				//If we have twice as many samples, we only need ~1/2 the alpha per sample.
+				//Scaling by 256/10 just happens to give a good value for the alphaCorrection slider.
+				float alphaScaleFactor = 25.6 * delta;
+
 				vec4 colorSample;
 				float alphaSample;
 
 				//Perform the ray marching iterations
 				for(int i = 0; i < MAX_STEPS; i++)
 				{
-					//Get the voxel intensity value from the 3D texture.	
+					//Get the voxel intensity value from the 3D texture.
 					colorSample = sampleAs3DTexture( currentPosition );
-				  
-					//Allow the alpha correction customization
+
+					//Allow the alpha correction customization.
 					alphaSample = colorSample.a * alphaCorrection;
 
+					//Applying this effect to both the color and alpha accumulation results in more realistic transparency.
+					alphaSample *= (1.0 - accumulatedAlpha);
+
+					//Scaling alpha by the number of steps makes the final color invariant to the step size.
+					alphaSample *= alphaScaleFactor;
+
 					//Perform the composition.
-					accumulatedColor += (1.0 - accumulatedAlpha) * colorSample * alphaSample;
-					
+					accumulatedColor += colorSample * alphaSample;
+
 					//Store the alpha accumulated so far.
 					accumulatedAlpha += alphaSample;
-					
+
 					//Advance the ray.
 					currentPosition += deltaDirection;
 					accumulatedLength += deltaDirectionLength;
-							  
+
 					//If the length traversed is more than the ray length, or if the alpha accumulated reaches 1.0 then exit.
 					if(accumulatedLength >= rayLength || accumulatedAlpha >= 1.0 )
 						break;
 				}
 
 				gl_FragColor  = accumulatedColor;
-				  
+
 			}
 		</script>
-		
+
 		<script id="vertexShaderSecondPass" type="x-shader/x-vertex">
 			varying vec3 worldSpaceCoords;
 			varying vec4 projectedCoords;
-			
+
 			void main()
 			{
 				worldSpaceCoords = (modelMatrix * vec4(position + vec3(0.5, 0.5,0.5), 1.0 )).xyz;
@@ -189,7 +203,7 @@
 				projectedCoords =  projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 			}
 		</script>
-		
+
 		<script>
 			if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
 
@@ -201,7 +215,7 @@
 			var cubeTextures = ['bonsai', 'foot', 'teapot'];
 			var histogram = [];
 			var guiControls;
-			
+
 			var materialSecondPass;
 			init();
 			animate();
@@ -212,7 +226,7 @@
 				guiControls = new function() {
 					this.model = 'bonsai';
 					this.steps = 256.0;
-					this.alphaCorrection = 0.10;
+					this.alphaCorrection = 1.0;
 					this.color1 = "#00FA58";
 					this.stepPos1 = 0.1;
 					this.color2 = "#CC6600";
@@ -220,7 +234,7 @@
 					this.color3 = "#F2F200";
 					this.stepPos3 = 1.0;
 				};
-				
+
 				container = document.getElementById( 'container' );
 
 				camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 0.01, 3000.0 );
@@ -229,7 +243,7 @@
 				controls = new THREE.OrbitControls( camera, container );
 				controls.center.set( 0.0, 0.0, 0.0 );
 
-									   
+
 				//Load the 2D texture containing the Z slices.
 				cubeTextures['bonsai'] = THREE.ImageUtils.loadTexture('bonsai.raw.png' );
 				cubeTextures['teapot'] = THREE.ImageUtils.loadTexture('teapot.raw.png');
@@ -240,7 +254,7 @@
 				cubeTextures['bonsai'].generateMipmaps = false;
 				cubeTextures['bonsai'].minFilter = THREE.LinearFilter;
 				cubeTextures['bonsai'].magFilter = THREE.LinearFilter;
-									
+
 				cubeTextures['teapot'].generateMipmaps = false;
 				cubeTextures['teapot'].minFilter = THREE.LinearFilter;
 				cubeTextures['teapot'].magFilter = THREE.LinearFilter;
@@ -249,35 +263,35 @@
 				cubeTextures['foot'].minFilter = THREE.LinearFilter;
 				cubeTextures['foot'].magFilter = THREE.LinearFilter;
 
-				
+
 				var transferTexture = updateTransferFunction();
-			
+
 				var screenSize = new THREE.Vector2( window.innerWidth, window.innerHeight );
 				rtTexture = new THREE.WebGLRenderTarget( screenSize.x, screenSize.y,
 														{ 	minFilter: THREE.LinearFilter,
 															magFilter: THREE.LinearFilter,
 															wrapS:  THREE.ClampToEdgeWrapping,
 															wrapT:  THREE.ClampToEdgeWrapping,
-															format: THREE.RGBFormat, 
-															type: THREE.FloatType, 
+															format: THREE.RGBFormat,
+															type: THREE.FloatType,
 															generateMipmaps: false} );
 
-				
+
 				var materialFirstPass = new THREE.ShaderMaterial( {
 					vertexShader: document.getElementById( 'vertexShaderFirstPass' ).textContent,
 					fragmentShader: document.getElementById( 'fragmentShaderFirstPass' ).textContent,
 					side: THREE.BackSide
 				} );
-				
+
 				materialSecondPass = new THREE.ShaderMaterial( {
 					vertexShader: document.getElementById( 'vertexShaderSecondPass' ).textContent,
 					fragmentShader: document.getElementById( 'fragmentShaderSecondPass' ).textContent,
 					side: THREE.FrontSide,
-					uniforms: {	tex:  { type: "t", value: rtTexture }, 
-								cubeTex:  { type: "t", value: cubeTextures['bonsai'] }, 
+					uniforms: {	tex:  { type: "t", value: rtTexture },
+								cubeTex:  { type: "t", value: cubeTextures['bonsai'] },
 								transferTex:  { type: "t", value: transferTexture },
 								steps : {type: "1f" , value: guiControls.steps },
-								alphaCorrection : {type: "1f" , value: guiControls.alphaCorrection }}		
+								alphaCorrection : {type: "1f" , value: guiControls.alphaCorrection }}
 				 });
 
 				sceneFirstPass = new THREE.Scene();
@@ -285,13 +299,13 @@
 
 				var boxGeometry = new THREE.BoxGeometry(1.0, 1.0, 1.0);
 				boxGeometry.doubleSided = true;
-				
+
 				var meshFirstPass = new THREE.Mesh( boxGeometry, materialFirstPass );
 				var meshSecondPass = new THREE.Mesh( boxGeometry, materialSecondPass );
-						
+
 				sceneFirstPass.add( meshFirstPass );
 				sceneSecondPass.add( meshSecondPass );
-				
+
 				renderer = new THREE.WebGLRenderer();
 				container.appendChild( renderer.domElement );
 
@@ -300,34 +314,34 @@
 				stats.domElement.style.top = '0px';
 				container.appendChild( stats.domElement );
 
-				
+
 				var gui = new dat.GUI();
 				var modelSelected = gui.add(guiControls, 'model', [ 'bonsai', 'foot', 'teapot' ] );
 				gui.add(guiControls, 'steps', 0.0, 512.0);
 				gui.add(guiControls, 'alphaCorrection', 0.01, 5.0).step(0.01);
-								
+
 				modelSelected.onChange(function(value) { materialSecondPass.uniforms.cubeTex.value =  cubeTextures[value]; } );
-				
-				
+
+
 				//Setup transfer function steps.
 				var step1Folder = gui.addFolder('Step 1');
 				var controllerColor1 = step1Folder.addColor(guiControls, 'color1');
 				var controllerStepPos1 = step1Folder.add(guiControls, 'stepPos1', 0.0, 1.0);
 				controllerColor1.onChange(updateTextures);
 				controllerStepPos1.onChange(updateTextures);
-				
+
 				var step2Folder = gui.addFolder('Step 2');
 				var controllerColor2 = step2Folder.addColor(guiControls, 'color2');
 				var controllerStepPos2 = step2Folder.add(guiControls, 'stepPos2', 0.0, 1.0);
 				controllerColor2.onChange(updateTextures);
 				controllerStepPos2.onChange(updateTextures);
-				
+
 				var step3Folder = gui.addFolder('Step 3');
 				var controllerColor3 = step3Folder.addColor(guiControls, 'color3');
 				var controllerStepPos3 = step3Folder.add(guiControls, 'stepPos3', 0.0, 1.0);
 				controllerColor3.onChange(updateTextures);
 				controllerStepPos3.onChange(updateTextures);
-						
+
 				step1Folder.open();
 				step2Folder.open();
 				step3Folder.open();
@@ -338,7 +352,7 @@
 				window.addEventListener( 'resize', onWindowResize, false );
 
 			}
-			
+
 			function updateTextures(value)
 			{
 				materialSecondPass.uniforms.transferTex.value = updateTransferFunction();
@@ -350,27 +364,27 @@
 				canvas.width = 256;
 
 				var ctx = canvas.getContext('2d');
-			
+
 				var grd = ctx.createLinearGradient(0, 0, canvas.width -1 , canvas.height - 1);
-				grd.addColorStop(guiControls.stepPos1, guiControls.color1);   
-				grd.addColorStop(guiControls.stepPos2, guiControls.color2);  
-				grd.addColorStop(guiControls.stepPos3, guiControls.color3);  
-				
+				grd.addColorStop(guiControls.stepPos1, guiControls.color1);
+				grd.addColorStop(guiControls.stepPos2, guiControls.color2);
+				grd.addColorStop(guiControls.stepPos3, guiControls.color3);
+
 				ctx.fillStyle = grd;
 				ctx.fillRect(0,0,canvas.width -1 ,canvas.height -1 );
-				
+
 				var img = document.getElementById("transferFunctionImg");
 				img.src = canvas.toDataURL();
 				img.style.width = "256 px";
 				img.style.height = "128 px";
-				
+
 				transferTexture =  new THREE.Texture(canvas);
 				transferTexture.wrapS = transferTexture.wrapT =  THREE.ClampToEdgeWrapping;
 				transferTexture.needsUpdate = true;
 
 				return transferTexture;
 			}
-			
+
 			function onWindowResize( event ) {
 
 				camera.aspect = window.innerWidth / window.innerHeight;
@@ -390,13 +404,13 @@
 			function render() {
 
 				var delta = clock.getDelta();
-				
+
 				//Render first pass and store the world space coords of the back face fragments into the texture.
 				renderer.render( sceneFirstPass, camera, rtTexture, true );
-				
+
 				//Render the second pass and perform the volume rendering.
 				renderer.render( sceneSecondPass, camera );
-				
+
 				materialSecondPass.uniforms.steps.value = guiControls.steps;
 				materialSecondPass.uniforms.alphaCorrection.value = guiControls.alphaCorrection;
 			}


### PR DESCRIPTION
The most important change is how accumulatedAlpha is incremented. By scaling the added alpha by the transmittance, that is to say (1-accumulatedAlpha), the transparency effect is much improved. In practice I did this by just changing where (1-accumulatedAlpha) was being applied (from accumulatedColor to alphaSample).

Think of it this way: if you have been tracing a ray through, and you are at 0.9 accumulated alpha, and the current alphaSample is 0.5, then the next accumulatedAlpha amount will be 0.95. This is interpreted as 50% of the "light" going through that sample permeates it, while 90% of the remainder is screened before it reaches the observer. 

For what it is worth, this is the standard way to do forward alpha composition.

The opacity was dependent upon the number of samples. I scaled the alphaSample by a value proportional to the number of steps to stop this. I simultaneously normalized the AlphaCorrection GUI around a value of 1.0

Looking diagonally through the cube would cause the ray to stop before it reached the back-face if the "step" value was sufficiently high. I increased MAX_STEPS to the smallest value that will prevent this. 
